### PR TITLE
Fix use of ssl_version in HTTPSConnection

### DIFF
--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -159,18 +159,17 @@ class HTTPConnection(_HTTPConnection, object):
 
 class HTTPSConnection(HTTPConnection):
     default_port = port_by_scheme['https']
-    ssl_version = None
 
     def __init__(self, host, port=None, key_file=None, cert_file=None,
                  strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
-                 ssl_context=None, **kw):
+                 ssl_context=None, ssl_version=None, **kw):
 
         HTTPConnection.__init__(self, host, port, strict=strict,
                                 timeout=timeout, **kw)
 
         if ssl_context is None:
             ssl_context = create_urllib3_context(
-                ssl_version=resolve_ssl_version(self.ssl_version),
+                ssl_version=resolve_ssl_version(ssl_version),
                 cert_reqs=ssl.CERT_NONE,
             )
 

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -671,7 +671,6 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                           ca_certs=self.ca_certs,
                           assert_hostname=self.assert_hostname,
                           assert_fingerprint=self.assert_fingerprint)
-            conn.ssl_version = self.ssl_version
 
         if self.proxy is not None:
             # Python 2.7+
@@ -712,7 +711,9 @@ class HTTPSConnectionPool(HTTPConnectionPool):
 
         conn = self.ConnectionCls(host=actual_host, port=actual_port,
                                   timeout=self.timeout.connect_timeout,
-                                  strict=self.strict, **self.conn_kw)
+                                  strict=self.strict,
+                                  ssl_version=self.ssl_version,
+                                  **self.conn_kw)
 
         return self._prepare_conn(conn)
 


### PR DESCRIPTION
Pass ssl_version when creating the SSLContext in the HTTPSConnection
constructor. HTTPSConnection.ssl_version is removed with this change,
since it can't be changed in the SSLContext after the constructor has
been called.
